### PR TITLE
Initialise variables to ensure input thread is started

### DIFF
--- a/src/arch/InputHandler/InputHandler_Linux_Event.cpp
+++ b/src/arch/InputHandler/InputHandler_Linux_Event.cpp
@@ -271,10 +271,11 @@ EventDevice::~EventDevice()
 }
 
 InputHandler_Linux_Event::InputHandler_Linux_Event()
+	: m_bShutdown(true)
+	, m_bDevicesChanged(false)
+	, m_bHaveKeyboard(false)
+	, m_NextDevice(DEVICE_JOY10)
 {
-	m_NextDevice = DEVICE_JOY10;
-	m_bDevicesChanged = false;
-
 	if(LINUXINPUT == NULL) LINUXINPUT = new LinuxInputManager;
 	LINUXINPUT->InitDriver(this);
 


### PR DESCRIPTION
m_bShutdown was not initialised. This meant that the input
thread would never be started seemingly at random.

In my case m_bShutdown was always false when running in fullscreen
but not in windowed mode for some reason